### PR TITLE
Enables cleaner to delete message from non supergroups

### DIFF
--- a/cleaner.py
+++ b/cleaner.py
@@ -9,7 +9,7 @@ from pyrogram.errors import FloodWait, UnknownError
 
 
 API_ID = getenv('API_ID', None) or int(input('Enter your Telegram API id: '))
-API_HASH = getenv('API_ID', None) or input('Enter your Telegram API hash: ')
+API_HASH = getenv('API_HASH', None) or input('Enter your Telegram API hash: ')
 
 app = Client("client", api_id=API_ID, api_hash=API_HASH)
 app.start()
@@ -21,10 +21,24 @@ class Cleaner:
         self.chat_id = chat_id
         self.message_ids = []
         self.add_offset = 0
+        self.group_type = ''
 
     def select_supergroup(self):
         dialogs = app.get_dialogs()
-        groups = [x for x in dialogs if x.chat.type == 'supergroup']
+
+        print('1. Supergroup\n2. (non super)Group')
+        group_type_n = int(input('Insert group type: '))
+        print('')
+
+        if group_type_n == 1:
+            self.group_type = 'supergroup'
+        elif group_type_n == 2:
+            self.group_type = 'group'
+        else:
+            print('Invalid group type. Exiting..')
+            exit()
+
+        groups = [x for x in dialogs if x.chat.type == self.group_type ]
 
         for i, group in enumerate(groups):
             print(f'{i+1}. {group.chat.title}')
@@ -45,8 +59,12 @@ class Cleaner:
     def run(self):
         q = self.search_messages()
         self.update_ids(q)
-        messages_count = q.count
-        print(f'Found {messages_count} your messages in selected supergroup')
+
+        if self.group_type == 'group':
+            messages_count = len(q["messages"])
+        else:
+            messages_count = q.count
+        print(f'Found {messages_count} your messages in selected %s' %self.group_type)
 
         if messages_count < 100:
             pass


### PR DESCRIPTION
This PR will let the user choose between super groups and non super groups at the startup. Afterwards the program runs as usually.
There was only a fix needed for the `q.count`.

Additionally I fixed receiving the `API_HASH` as an environment variable. There were two times `API_ID`.

Sample Output:

```
jonny@xxxx:~/telegram-delete-all-messages$ python3 cleaner.py 
Pyrogram v0.17.1, Copyright (C) 2017-2020 Dan <https://github.com/delivrance>
Licensed under the terms of the GNU Lesser General Public License v3 or later (LGPLv3+)

1. Supergroup
2. (non super)Group
Insert group type: 2

1. yyyyyyyyyyyyyyyyyyyy
2. xxxxxxxxxxxxxxxxxxxx
3. xxxxxxxxxxxxxxxxxxxx
4. xxxxxxxxxxxxxxxxxxxx 
5. xxxxxxxxxxxxxxxxxxxx
6. xxxxxxxxxxxxxxxxxxxx
7. xxxxxxxxxxxxxxxxxxxx
8. xxxxxxxxxxxxxxxxxxxx
9. xxxxxxxxxxxxxxxxxxxx
10. xxxxxxxxxxxxxxxxxxx
11. xxxxxxxxxxxxxxxxxxx
12. xxxxxxxxxxxxxxxxxxx
13. xxxxxxxxxxxxxxxxxxx
14. xxxxxxxxxxxxxxxxxxx
15. xxxxxxxxxxxxxxxxxxx
16. xxxxxxxxxxxxxxxxxxx
17. xxxxxxxxxxxxxxxxxxx
18. xxxxxxxxxxxxxxxxxxx
19. xxxxxxxxxxxxxxxxxxx
20. xxxxxxxxxxxxxxxxxxx
21. xxxxxxxxxxxxxxxxxxx
22. xxxxxxxxxxxxxxxxxxx
23. xxxxxxxxxxxxxxxxxxx
24. xxxxxxxxxxxxxxxxxxx
25. xxxxxxxxxxxxxxxxxxx
26. xxxxxxxxxxxxxxxxxxx
27. xxxxxxxxxxxxxxxxxxx
28. xxxxxxxxxxxxxxxxxxx
29. xxxxxxxxxxxxxxxxxxx
30. xxxxxxxxxxxxxxxxxxx
31. xxxxxxxxxxxxxxxxxxx
32. xxxxxxxxxxxxxxxxxxx
33. xxxxxxxxxxxxxxxxxxx
34. xxxxxxxxxxxxxxxxxxx
35. xxxxxxxxxxxxxxxxxxx
36. xxxxxxxxxxxxxxxxxxx
37. xxxxxxxxxxxxxxxxxxx
38. xxxxxxxxxxxxxxxxxxx
39. xxxxxxxxxxxxxxxxxxx
40. xxxxxxxxxxxxxxxxxxx
41. xxxxxxxxxxxxxxxxxxx
42. xxxxxxxxxxxxxxxxxxx
43. xxxxxxxxxxxxxxxxxxx
44. xxxxxxxxxxxxxxxxxxx
45. xxxxxxxxxxxxxxxxxxx

Insert group number: 1
Selected yyyyyyyyyyyyyyy

Searching messages. OFFSET: 0
Found 2 your messages in selected group
Deleting 2 messages with next message IDs:
[xx18, xxx14]
```