### PR TITLE
Add "delete all messages in all groups", simplify, cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ To install this script you have to download project and install requirements:
 
 ### Linux
 ```
-git clone https://github.com/borontov/telegram-delete-all-messages
+git clone https://github.com/gurland/telegram-delete-all-messages
 cd telegram-delete-all-messages
 pip install -r requirements.txt
 python cleaner.py

--- a/cleaner.py
+++ b/cleaner.py
@@ -46,14 +46,26 @@ class Cleaner:
         print('Delete all your messages in')
         for i, group in enumerate(groups):
             print(f'  {i+1}. {group.title}')
-        print(f'  {len(groups) + 1}. (!) ALL OF THE ABOVE (!)\n')
+
+        print(
+            f'  {len(groups) + 1}. '
+            '(!) DELETE ALL YOUR MESSAGES IN ALL OF THOSE GROUPS (!)\n'
+        )
 
         n = int(input('Insert option number: '))
         if not 1 <= n <= len(groups) + 1:
             print('Invalid option selected. Exiting...')
             exit(-1)
 
-        self.chats = groups if n == len(groups) + 1 else [groups[n - 1]]
+        if n == len(groups) + 1:
+            print('\nTHIS WILL DELETE ALL YOUR MESSSAGES IN ALL GROUPS!')
+            answer = input('Please type "I understand" to proceed: ')
+            if answer.upper() != 'I UNDERSTAND':
+                print('Better safe than sorry. Aborting...')
+                exit(-1)
+            self.chats = groups
+        else:
+            self.chats = [groups[n - 1]]
 
         print(f'\nSelected {", ".join(c.title for c in self.chats)}.\n')
 

--- a/cleaner.py
+++ b/cleaner.py
@@ -16,9 +16,10 @@ app.start()
 
 
 class Cleaner:
-    def __init__(self, chats=None, search_limit=1000):
+    def __init__(self, chats=None, search_limit=1000, delete_chunk_size=100):
         self.chats = chats or []
         self.search_limit = search_limit
+        self.delete_chunk_size = delete_chunk_size
 
     @staticmethod
     def chunks(l, n):
@@ -53,7 +54,7 @@ class Cleaner:
             exit(-1)
 
         self.chats = groups if n == len(groups) + 1 else [groups[n - 1]]
- 
+
         print(f'\nSelected {", ".join(c.title for c in self.chats)}.\n')
 
     def run(self):
@@ -76,11 +77,9 @@ class Cleaner:
     def delete_messages(self, chat_id, message_ids):
         print(f'Deleting {len(message_ids)} messages with message IDs:')
         print(message_ids)
-        for message_ids_chunk in self.chunks(message_ids, 100):
+        for chunk in self.chunks(message_ids, self.delete_chunk_size):
             try:
-                app.delete_messages(
-                    chat_id=chat_id,
-                    message_ids=message_ids_chunk)
+                app.delete_messages(chat_id=chat_id, message_ids=chunk)
             except FloodWait as flood_exception:
                 sleep(flood_exception.x)
 

--- a/cleaner.py
+++ b/cleaner.py
@@ -22,7 +22,6 @@ class Cleaner:
         self.search_limit = search_limit
         self.message_ids = []
         self.add_offset = 0
-        self.group_type = ''
 
     @staticmethod
     def chunks(l, n):
@@ -42,23 +41,9 @@ class Cleaner:
 
         return dialogs
 
-    def select_supergroup(self):
-        group_types = {
-            '1': 'supergroup',
-            '2': 'group'
-        }
-
+    def select_group(self):
         dialogs = self.get_all_dialogs()
-
-        print('\n'.join((f'{i}. {name.capitalize()}' for i, name in group_types.items())))
-        try:
-            self.group_type = group_types[input('Insert group type number: ')]
-        except KeyError:
-            print('Invalid group type. Exiting..')
-            exit(-1)
-        print('')
-
-        groups = [x for x in dialogs if x.chat.type == self.group_type]
+        groups = [d for d in dialogs if d.chat.type in ('group', 'supergroup')]
 
         for i, group in enumerate(groups):
             print(f'{i+1}. {group.chat.title}')
@@ -85,7 +70,7 @@ class Cleaner:
             q = self.search_messages()
             self.update_ids(q)
             messages_count = len(q['messages'])
-            print(f'Found {messages_count} of your messages in selected {self.group_type}')
+            print(f'Found {messages_count} of your messages in selected group')
             if messages_count < self.search_limit:
                 break
             self.add_offset += self.search_limit
@@ -131,7 +116,7 @@ class Cleaner:
 if __name__ == '__main__':
     try:
         deleter = Cleaner()
-        deleter.select_supergroup()
+        deleter.select_group()
         deleter.run()
     except UnknownError as e:
         print(f'UnknownError occured: {e}')

--- a/cleaner.py
+++ b/cleaner.py
@@ -67,7 +67,8 @@ class Cleaner:
         else:
             self.chats = [groups[n - 1]]
 
-        print(f'\nSelected {", ".join(c.title for c in self.chats)}.\n')
+        groups_str = ', '.join(c.title for c in self.chats)
+        print(f'\nSelected {groups_str}.\n')
 
     def run(self):
         for chat in self.chats:


### PR DESCRIPTION
This PR will

- add the "delete all messages in all groups" feature (issue https://github.com/gurland/telegram-delete-all-messages/issues/12)
- get rid of the differentiation between groups and supergroups (saving one user input dialog and simplifying the code)
- make the deletion chunk size configurable in the constructor
- do some minor refactoring and cleanup
- fix the git clone URL in README.md which is currently pointing to a fork rather than the original