### PR TITLE
Supports bots and fixes searching > 100 messages

### DIFF
--- a/cleaner.py
+++ b/cleaner.py
@@ -7,7 +7,6 @@ from pyrogram.raw.types import InputPeerSelf, InputMessagesFilterEmpty
 from pyrogram.raw.types.messages import ChannelMessages
 from pyrogram.errors import FloodWait, UnknownError
 
-
 API_ID = getenv('API_ID', None) or int(input('Enter your Telegram API id: '))
 API_HASH = getenv('API_HASH', None) or input('Enter your Telegram API hash: ')
 
@@ -16,11 +15,13 @@ app.start()
 
 
 class Cleaner:
-    def __init__(self, chats=None, search_limit=1000, delete_chunk_size=100):
+    def __init__(self, chats=None, search_chunk_size=1000, delete_chunk_size=100, search_limit=5000, offset=10):
         self.chats = chats or []
-        self.search_limit = search_limit
+        self.search_chunk_size = search_chunk_size
         self.delete_chunk_size = delete_chunk_size
-
+        self.search_limit = search_limit
+        self.offset = offset
+        
     @staticmethod
     def chunks(l, n):
         """Yield successive n-sized chunks from l.
@@ -41,11 +42,15 @@ class Cleaner:
 
     def select_groups(self):
         chats = self.get_all_chats()
-        groups = [c for c in chats if c.type in ('group', 'supergroup')]
+        groups = [c for c in chats if c.type in ('bot', 'group', 'supergroup')]
 
-        print('Delete all your messages in')
+        print('Delete all messages in which of the following groups:')
         for i, group in enumerate(groups):
-            print(f'  {i+1}. {group.title}')
+            if group.type == 'bot':
+                group_name = group.first_name
+            elif group.type in ('group', 'supergroup'):
+                group_name = group.title
+            print(f'  {i+1}. {group_name} ({group.type})')
 
         print(
             f'  {len(groups) + 1}. '
@@ -67,37 +72,64 @@ class Cleaner:
         else:
             self.chats = [groups[n - 1]]
 
-        groups_str = ', '.join(c.title for c in self.chats)
-        print(f'\nSelected {groups_str}.\n')
+        groups_str = ""
+        for c in self.chats:
+            if c.type == 'bot':
+                groups_str += f"{c.first_name}\n"
+            elif c.type in ('group', 'supergroup'):
+                groups_str += f"{c.title}\n"
+
+        print(f'\nDeleting messages from:\n{groups_str}')
 
     def run(self):
         for chat in self.chats:
             peer = app.resolve_peer(chat.id)
             message_ids = []
-            add_offset = 0
-
+            q = self.get_total_messages(peer)
+            add_offset = self.offset
+            chat_tot_messages = q.count
+            if chat.type == 'bot':
+                group_name = chat.first_name
+            elif chat.type in ('group', 'supergroup'):
+                group_name = chat.title
+            print(f'Found {chat_tot_messages} of your messages in "{group_name}"')
+            print(f'Offset by {add_offset} latest messages')
+            print(f'Searching up to the defined limit of {self.search_limit}')
             while True:
-                q = self.search_messages(peer, add_offset)
-                message_ids.extend(msg.id for msg in q['messages'])
-                messages_count = len(q['messages'])
-                print(f'Found {messages_count} of your messages in "{chat.title}"')
-                if messages_count < self.search_limit:
+                a = self.search_messages(chat.id, add_offset)
+                message_ids.extend(msg.message_id for msg in a)
+                tot_messages = len(message_ids)
+                messages_count = len(a)
+                if messages_count < self.search_chunk_size:
+                    print(f'Deleting {messages_count} messages...\n')
                     break
-                add_offset += self.search_limit
+                if tot_messages >= self.search_limit:
+                    print(f'Deleting {tot_messages} messages (defined search limit)...\n')
+                    break
+                add_offset += self.search_chunk_size
 
-            self.delete_messages(chat.id, message_ids)
+            # 
+            self.delete_messages(chat.id, message_ids, peer)
 
-    def delete_messages(self, chat_id, message_ids):
-        print(f'Deleting {len(message_ids)} messages with message IDs:')
-        print(message_ids)
+    def delete_messages(self, chat_id, message_ids, peer):
         for chunk in self.chunks(message_ids, self.delete_chunk_size):
             try:
                 app.delete_messages(chat_id=chat_id, message_ids=chunk)
             except FloodWait as flood_exception:
                 sleep(flood_exception.x)
+        sleep(1)
+        q = self.get_total_messages(peer)
+        print(f'{q.count} messages remaining...')
 
-    def search_messages(self, peer, add_offset):
-        print(f'Searching messages. OFFSET: {add_offset}')
+    def search_messages(self, chat_id, add_offset):
+        return app.search_messages(
+            chat_id, 
+            limit=self.search_chunk_size,
+            offset=add_offset
+        )
+        tot_messages = len(a)
+
+    def get_total_messages(self, peer):
         return app.send(
             Search(
                 peer=peer,
@@ -106,12 +138,12 @@ class Cleaner:
                 min_date=0,
                 max_date=0,
                 offset_id=0,
-                add_offset=add_offset,
-                limit=self.search_limit,
+                add_offset=0,
+                limit=1,
                 max_id=0,
                 min_id=0,
                 hash=0,
-                from_id=InputPeerSelf()
+                # from_id=InputPeerSelf()
             )
         )
 


### PR DESCRIPTION
First of all, apologies for my poor Python, this is my first go at coding with it!

I wanted to support the 'bot' group type so that I could delete a 39,000 message group used for Home Assistant messages, and I also wanted to search for more than 100 messages at a time, but soon found that the Pyrogram raw search wouldn't allow this (see https://github.com/pyrogram/pyrogram/issues/637).

I therefore had a go at fixing both of these issues, resulting in this pull request. I'm surprised I managed to make it all work! 

It now lists bot, group, and supergroups, and caters for the fact that bots don't use 'title'. There are probably more elegant ways to my for loops, but they do the job. 

One change that might be a problem is that I removed the `from_id` element from search because it wouldn't find any bot messages or delete all messages within a group I owned. If you aren't the group owner, would it still only delete your messages anyway? I can't test this unfortunately as I don't have any other groups. 

I re-purposed the `search_limit` variable so that a user could specify how many messages to delete at once for testing purposes. You may only want to delete 50 messages at first to check it works as expected, rather than going full on and deleting everything first run.

The old `search_limit` variable was changed to `search_chunk_size` as discussed and suggested by @hannesveit [here](https://github.com/gurland/telegram-delete-all-messages/issues/31#issuecomment-797493545)

I think that covers all the changes I made. Please go easy on me as this is not only my first Python code, but also my first pull request, so I hope it all works as expected.

Here is a sample output to show some of the changes:

```
Pyrogram v1.1.13, Copyright (C) 2017-2021 Dan <https://github.com/delivrance>
Licensed under the terms of the GNU Lesser General Public License v3 or later (LGPLv3+)

Delete all messages in which of the following groups:
  1. PiBot (bot)
  2. MyOtherGroup (group)
  3. get id (bot)
  4. BotFather (bot)
  5. (!) DELETE ALL YOUR MESSAGES IN ALL OF THOSE GROUPS (!)

Insert option number: 1

Deleting messages from:
PiBot

Found 29037 of your messages in "PiBot"
Offset by 10 latest messages
Searching up to the defined limit of 5000
Deleting 5000 messages (defined search limit)...

24037 messages remaining...
```