### PR TITLE
Feature delete messages older than x days or time stamp, message previews, and dry-run mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 ﻿venv/
+.venv/
 
 cache
 client.session


### PR DESCRIPTION
- accept either a day count or MM-DD-YYYY[ hh:mm] timestamp when choosing the deletion cutoff, normalize input to the user’s local timezone, and compare everything in UTC
- show per-message previews (id + first ~30 chars) for every message selected for deletion so it’s easy to verify what will be removed
- add --dry-run CLI flag to walk through the selection flow without actually deleting anything, and cleanly report when the script is only simulating deletions

Tested manually: python cleaner.py --dry-run and without the flag to confirm local-time cutoffs, previews, and dry-run behavior.