### PR TITLE
Feature to paste chat_id of specific group you are not currently in.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,19 @@
-# telegram-delete-all-messages
-Delete all your messages in supergroups with python script.
+# Telegram-Message-Cleaner
+
+Delete all your messages in specific group (with `chat_id`) using this python script
+Resources.
+
+> [!IMPORTANT]
+>
+> - **Script has been tested only on Linux.**
+> - **Instead of prompting super groups, this script prompts for id of specific chat. This helps delete messages from groups you are not currently in.**
 
 ## Installation
+
 To install this script you have to download project and install requirements:
 
 ### Linux
+
 ```
 git clone https://github.com/gurland/telegram-delete-all-messages
 cd telegram-delete-all-messages
@@ -13,27 +22,35 @@ python cleaner.py
 ```
 
 ### Windows
+
 - Download zip file from this repo and unpack it
 - Install latest [CPython 3](https://www.python.org) version
 - Run install.bat
 - Run start.bat
 
 ## Obtain standalone telegram app API credentials
+
 - Login to https://my.telegram.org/
 - Select `API development tools` link
-- Create standalone application
+- Create standalone application (or use existing)
 - Copy app_id and app_hash
 
 ## Usage
-> You need both App api_id and App api_hash to use script.
 
-#### Environment variables
-You could set API_ID and API_HASH environment variables to prevent entering API credentials manually.
+You need both App `api_id`, App `api_hash`, & `chat_id` to use script.
 
-#### Start
+### Environment variables
+
+You could set `API_ID` and `API_HASH` environment variables to prevent entering API credentials manually.
+
+### Start
+
 After starting script you will be prompted:
+
 - To enter your Telegram APP credentials (if no environment variables found)
 - Your account phone and then code sent to you by Telegram
+- Instead of prompting super groups, this script prompts for id of specific chat.
+
 ```
 $ python cleaner.py
 
@@ -45,22 +62,21 @@ Licensed under the terms of the GNU Lesser General Public License v3 or later (L
 Enter phone number: +123456789012
 Is "+123456789012" correct? (y/n): y
 Enter phone code: 88988
-Logged in successfully as Stanislav
+Logged in successfully as User
+Enter chat_id: XXXXXXXXXXXXXXXXXXXX
 ```
 
-#### Choosing supergroup
-- After providing needed information you will get your supergroup dialogs
-- Enter number found near desired supergroup title
-```
-1. Python community
-2. Rust Beginners
-3. IDE & Editors
+### Get chat_id
 
-Insert group number:
-```
+In web-telegram, login to web telegram on PC with phone. Open browser dev. tools with 'CTRL+SHIFT+C' or 'Right-click' and click `Inspect`. Click on the icon of the chat or somewhere in the area of chat, the `chat_id` should be displayed under `data-peer-id` or `peer`. `Chat.<title>` is going to be displayed before removal of messages.
 
-#### Message removal process
+> [!NOTE]
+> **If this method is not working or you are confused, you can find some other method online.**
+
+### Message removal process
+
 - After choosing supergroup you would get informed about messages removal process
+
 ```
 Insert group number: 2
 Selected Rust Beginners

--- a/cleaner.py
+++ b/cleaner.py
@@ -8,6 +8,7 @@ from pyrogram.raw.functions.messages import Search
 from pyrogram.raw.types import InputPeerSelf, InputMessagesFilterEmpty
 from pyrogram.raw.types.messages import ChannelMessages
 from pyrogram.errors import FloodWait, UnknownError
+from pyrogram.enums import ChatType
 
 cachePath = os.path.abspath(__file__)
 cachePath = os.path.dirname(cachePath)
@@ -16,7 +17,7 @@ cachePath = os.path.join(cachePath, "cache")
 if os.path.exists(cachePath):
     with open(cachePath, "r") as cacheFile:
         cache = json.loads(cacheFile.read())
-    
+
     API_ID = cache["API_ID"]
     API_HASH = cache["API_HASH"]
 else:
@@ -24,6 +25,7 @@ else:
     API_HASH = os.getenv('API_HASH', None) or input('Enter your Telegram API hash: ')
 
 app = Client("client", api_id=API_ID, api_hash=API_HASH)
+app.start()
 
 if not os.path.exists(cachePath):
     with open(cachePath, "w") as cacheFile:
@@ -32,8 +34,7 @@ if not os.path.exists(cachePath):
 
 
 class Cleaner:
-    def __init__(self, chats=None, search_chunk_size=100, delete_chunk_size=100):
-        self.chats = chats or []
+    def __init__(self, search_chunk_size=100, delete_chunk_size=100):
         if search_chunk_size > 100:
             # https://github.com/gurland/telegram-delete-all-messages/issues/31
             #
@@ -51,94 +52,61 @@ class Cleaner:
         for i in range(0, len(l), n):
             yield l[i:i + n]
 
-    @staticmethod
-    async def get_all_chats():        
-        async with app:
-            dialogs = []
-            async for dialog in app.get_dialogs():
-                dialogs.append(dialog.chat)
-            return dialogs
-
-    async def select_groups(self, recursive=0):
-        chats = await self.get_all_chats()
-        groups = [c for c in chats if c.type.name in ('GROUP, SUPERGROUP')]
-
-        print('Delete all your messages in')
-        for i, group in enumerate(groups):
-            print(f'  {i+1}. {group.title}')
-
-        print(
-            f'  {len(groups) + 1}. '
-            '(!) DELETE ALL YOUR MESSAGES IN ALL OF THOSE GROUPS (!)\n'
-        )
-
-        nums_str = input('Insert option numbers (comma separated): ')
-        nums = map(lambda s: int(s.strip()), nums_str.split(','))
-
-        for n in nums:
-            if not 1 <= n <= len(groups) + 1:
-                print('Invalid option selected. Exiting...')
-                exit(-1)
-
-            if n == len(groups) + 1:
-                print('\nTHIS WILL DELETE ALL YOUR MESSSAGES IN ALL GROUPS!')
-                answer = input('Please type "I understand" to proceed: ')
-                if answer.upper() != 'I UNDERSTAND':
-                    print('Better safe than sorry. Aborting...')
-                    exit(-1)
-                self.chats = groups
-                break
-            else:
-                self.chats.append(groups[n - 1])
-        
-        groups_str = ', '.join(c.title for c in self.chats)
-        print(f'\nSelected {groups_str}.\n')
-
-        if recursive == 1:
-            self.run()
-
-    async def run(self):
-        for chat in self.chats:
-            chat_id = chat.id
+    def run(self, chat_id):
+            peer = app.resolve_peer(chat_id)
             message_ids = []
             add_offset = 0
 
             while True:
-                q = await self.search_messages(chat_id, add_offset)
-                message_ids.extend(msg.id for msg in q)
-                messages_count = len(q)
-                print(f'Found {len(message_ids)} of your messages in "{chat.title}"')
+                q = self.search_messages(peer, add_offset)
+                #message_ids.extend(msg.id for msg in q['messages'])
+                #messages_count = len(q['messages'])
+                message_ids.extend(msg.id for msg in q.messages)
+                messages_count = len(q.messages)
+                print(f'Found {messages_count} of your messages in "{app.get_chat(chat_id).title}"')
                 if messages_count < self.search_chunk_size:
                     break
                 add_offset += self.search_chunk_size
 
-            await self.delete_messages(chat_id=chat.id, message_ids=message_ids)
+            self.delete_messages(chat_id, message_ids)
 
-    async def delete_messages(self, chat_id, message_ids):
+    def delete_messages(self, chat_id, message_ids):
         print(f'Deleting {len(message_ids)} messages with message IDs:')
         print(message_ids)
         for chunk in self.chunks(message_ids, self.delete_chunk_size):
             try:
-                async with app:
-                    await app.delete_messages(chat_id=chat_id, message_ids=chunk)
+                app.delete_messages(chat_id=chat_id, message_ids=chunk)
             except FloodWait as flood_exception:
                 sleep(flood_exception.x)
 
-    async def search_messages(self, chat_id, add_offset):
-        async with app:
-            messages = []
-            print(f'Searching messages. OFFSET: {add_offset}')
-            async for message in app.search_messages(chat_id=chat_id, offset=add_offset, from_user="me", limit=100):
-                messages.append(message)
-            return messages
+    def search_messages(self, peer, add_offset):
+        print(f'Searching messages. OFFSET: {add_offset}')
+        return app.invoke(
+        #return app.send(
+            Search(
+                peer=peer,
+                q='',
+                filter=InputMessagesFilterEmpty(),
+                min_date=0,
+                max_date=0,
+                offset_id=0,
+                add_offset=add_offset,
+                limit=self.search_chunk_size,
+                max_id=0,
+                min_id=0,
+                hash=0,
+                from_id=InputPeerSelf()
+            ),
+            sleep_threshold=60
+        )
 
-async def main():
+
+if __name__ == '__main__':
     try:
         deleter = Cleaner()
-        await deleter.select_groups()
-        await deleter.run()
+        deleter.run(int(input('Enter chat_id: ')))
     except UnknownError as e:
         print(f'UnknownError occured: {e}')
         print('Probably API has changed, ask developers to update this utility')
-
-app.run(main())
+    finally:
+        app.stop()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pyrogram==2.0.106
-tgcrypto # Optional, for faster cleaning. You could remove this line
+pyrogram
+tgcrypto


### PR DESCRIPTION
Solution to #90.
- Modified cleaner.py, requirements.txt, readme file.
- Instead of showing super-groups menu, it prompts for `chat_id`. **WARNING: removes super-groups-menu functionality.**
- Test: Works on Debian, **though pyrogram is not fixed to version, in other words, I have changed the requirements.txt**